### PR TITLE
Ruby 2.5.6 Upgrade

### DIFF
--- a/ext/cld/Makefile
+++ b/ext/cld/Makefile
@@ -1,6 +1,6 @@
 # TODO: Generate Makefile
 
-CFLAGS=-fPIC -I. -O2 -DCLD_WINDOWS
+CFLAGS=-fPIC -I. -O2 -DCLD_WINDOWS -ansi
 LDFLAGS=-L.
 CC=g++
 AR=ar

--- a/language_detection.gemspec
+++ b/language_detection.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "shoulda"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "turn"
+  gem.add_development_dependency "test-unit"
 end

--- a/test/_helper.rb
+++ b/test/_helper.rb
@@ -3,7 +3,7 @@ require 'bundler/setup'
 require 'test/unit'
 require 'shoulda'
 require 'turn' unless ENV["TM_FILEPATH"] || ENV["CI"]
-require 'mocha'
+require 'mocha/test_unit'
 require File.join(File.expand_path('../../lib/language_detection.rb', __FILE__))
 
 class Test::Unit::TestCase

--- a/test/language_detection_test.rb
+++ b/test/language_detection_test.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require '_helper'
+require './test/_helper'
 require 'csv'
 
 class LanguageDetectionTest < Test::Unit::TestCase


### PR DESCRIPTION
Overview
---
This gem is good to go for Ruby 2.5.6.

I just needed to make minor modifications to get the tests to run and pass.
To reproduce, make the changes in this commit and then:

```
bundle
rake
```

You should see this:

```
Started
.......
Finished in 0.006066 seconds.
-----------------------------------------------------------------------------------------------------
7 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------
```

I also installed this gem in a sample Ruby 2.5.6 project and ran the sample code in the README which checked out fine.
