### PR TITLE
Ruby 3.4 support 

### DIFF
--- a/language_detection.gemspec
+++ b/language_detection.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "shoulda", "~> 4"
   gem.add_development_dependency "mocha", "~> 2"
   gem.add_development_dependency "test-unit", "~> 3"
+  gem.add_development_dependency "csv", "~> 3"
 
   gem.required_ruby_version = [ ">= 2.5.0", "< 3.5" ]
 end

--- a/language_detection.gemspec
+++ b/language_detection.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.extensions    = ["ext/cld/extconf.rb"]
 
-  gem.add_runtime_dependency "ffi", "~> 1.15"
+  gem.add_runtime_dependency "ffi", "~> 1.17"
 
   gem.add_development_dependency "rake", "~> 13"
   gem.add_development_dependency "shoulda", "~> 4"

--- a/language_detection.gemspec
+++ b/language_detection.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "mocha", "~> 2"
   gem.add_development_dependency "test-unit", "~> 3"
 
-  gem.required_ruby_version = [ ">= 2.5.0", "< 3.3.0" ]
+  gem.required_ruby_version = [ ">= 2.5.0", "< 3.5" ]
 end


### PR DESCRIPTION
```
➜  language_detection git:(ruby-3.4) ✗ ruby -v          
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-darwin23]
➜  language_detection git:(ruby-3.4) ✗ bundle exec rake 
Extension already compiled. To recompile set env variable RECOMPILE=true.
/Users/oskarkapusta/.rbenv/versions/3.4.1/bin/ruby -w -I"lib:lib:test" /Users/oskarkapusta/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/language_detection_test.rb" 
/Users/oskarkapusta/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/shoulda-matchers-4.5.1/lib/shoulda/matchers/doublespeak.rb:2: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
Loaded suite /Users/oskarkapusta/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/rake_test_loader
Started
Finished in 0.008427 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
7 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
830.66 tests/s, 11154.62 assertions/s
```

> You can add logger to your Gemfile or gemspec to silence this warning.

What do you think?